### PR TITLE
Make fir logs burnable

### DIFF
--- a/src/main/resources/data/traverse/tags/blocks/fir_logs.json
+++ b/src/main/resources/data/traverse/tags/blocks/fir_logs.json
@@ -1,5 +1,6 @@
 {
   "values": [
+    "minecraft:logs_that_burn",
     "traverse:fir_log",
     "traverse:fir_wood",
     "traverse:stripped_fir_log",


### PR DESCRIPTION
Fir logs can't be smelted into charcoal in a furnace

My first Minecraft PR ever, so I don't know if this is really that's needed.