### PR TITLE
Allow crafting stripped fir wood from stripped fir logs

### DIFF
--- a/src/main/resources/data/traverse/advancements/recipes/building_blocks/stripped_fir_wood.json
+++ b/src/main/resources/data/traverse/advancements/recipes/building_blocks/stripped_fir_wood.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "traverse:stripped_fir_wood"
+    ]
+  },
+  "criteria": {
+    "has_stripped_log": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "traverse:stripped_fir_log"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "traverse:stripped_fir_wood"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stripped_log",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/traverse/recipes/stripped_fir_wood.json
+++ b/src/main/resources/data/traverse/recipes/stripped_fir_wood.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "bark",
+  "pattern": [
+    "LL",
+    "LL"
+  ],
+  "key": {
+    "L": {
+      "item": "traverse:stripped_fir_log"
+    }
+  },
+  "result": {
+    "item": "traverse:stripped_fir_wood",
+    "count": 3
+  }
+}


### PR DESCRIPTION
This pull request adds a recipe for stripped fir wood to maintain consistency with vanilla, similarly to TerraformersMC/Terrestria#236.