### PR TITLE
Add fir planks to #c:planks_that_burn (Blockus compatibility)

### DIFF
--- a/src/main/resources/data/c/tags/items/planks_that_burn.json
+++ b/src/main/resources/data/c/tags/items/planks_that_burn.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "traverse:fir_planks"
+  ]
+}


### PR DESCRIPTION
This pull request adds fir planks to the tag #c:planks_that_burn so that they can be used in Blockus' charred planks recipe. This is similar to [TerraformersMC/Terrestria#251](https://github.com/TerraformersMC/Terrestria/pull/251).