### PR TITLE
Fix tree leaves dropping themselves on decay

### DIFF
--- a/src/main/resources/data/traverse/loot_tables/blocks/fir_leaves.json
+++ b/src/main/resources/data/traverse/loot_tables/blocks/fir_leaves.json
@@ -2,7 +2,8 @@
   "type": "minecraft:block",
   "pools": [
 	{
-	  "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
 	  "entries": [
 		{
 		  "type": "minecraft:alternatives",
@@ -16,7 +17,9 @@
 					{
 					  "condition": "minecraft:match_tool",
 					  "predicate": {
-						"item": "minecraft:shears"
+                        "items": [
+                          "minecraft:shears"
+                        ]
 					  }
 					},
 					{
@@ -61,7 +64,8 @@
 	  ]
 	},
 	{
-	  "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
 	  "entries": [
 		{
 		  "type": "minecraft:item",
@@ -85,7 +89,8 @@
 				"min": 1.0,
 				"max": 2.0,
 				"type": "minecraft:uniform"
-			  }
+			  },
+              "add": false
 			},
 			{
 			  "function": "minecraft:explosion_decay"
@@ -103,7 +108,9 @@
 			  {
 				"condition": "minecraft:match_tool",
 				"predicate": {
-				  "item": "minecraft:shears"
+                  "items": [
+                    "minecraft:shears"
+                  ]
 				}
 			  },
 			  {

--- a/src/main/resources/data/traverse/loot_tables/blocks/orange_autumnal_leaves.json
+++ b/src/main/resources/data/traverse/loot_tables/blocks/orange_autumnal_leaves.json
@@ -2,7 +2,8 @@
   "type": "minecraft:block",
   "pools": [
 	{
-	  "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
 	  "entries": [
 		{
 		  "type": "minecraft:alternatives",
@@ -16,7 +17,9 @@
 					{
 					  "condition": "minecraft:match_tool",
 					  "predicate": {
-						"item": "minecraft:shears"
+                        "items": [
+                          "minecraft:shears"
+                        ]
 					  }
 					},
 					{
@@ -61,7 +64,8 @@
 	  ]
 	},
 	{
-	  "rolls": 1,
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
 	  "entries": [
 		{
 		  "type": "minecraft:item",
@@ -85,7 +89,8 @@
 				"min": 1.0,
 				"max": 2.0,
 				"type": "minecraft:uniform"
-			  }
+			  },
+              "add": false
 			},
 			{
 			  "function": "minecraft:explosion_decay"
@@ -103,7 +108,9 @@
 			  {
 				"condition": "minecraft:match_tool",
 				"predicate": {
-				  "item": "minecraft:shears"
+                  "items": [
+                    "minecraft:shears"
+                  ]
 				}
 			  },
 			  {

--- a/src/main/resources/data/traverse/loot_tables/blocks/red_autumnal_leaves.json
+++ b/src/main/resources/data/traverse/loot_tables/blocks/red_autumnal_leaves.json
@@ -1,128 +1,135 @@
 {
   "type": "minecraft:block",
   "pools": [
-	{
-	  "rolls": 1,
-	  "entries": [
-		{
-		  "type": "minecraft:alternatives",
-		  "children": [
-			{
-			  "type": "minecraft:item",
-			  "conditions": [
-				{
-				  "condition": "minecraft:alternative",
-				  "terms": [
-					{
-					  "condition": "minecraft:match_tool",
-					  "predicate": {
-						"item": "minecraft:shears"
-					  }
-					},
-					{
-					  "condition": "minecraft:match_tool",
-					  "predicate": {
-						"enchantments": [
-						  {
-							"enchantment": "minecraft:silk_touch",
-							"levels": {
-							  "min": 1
-							}
-						  }
-						]
-					  }
-					}
-				  ]
-				}
-			  ],
-			  "name": "traverse:red_autumnal_leaves"
-			},
-			{
-			  "type": "minecraft:item",
-			  "conditions": [
-				{
-				  "condition": "minecraft:survives_explosion"
-				},
-				{
-				  "condition": "minecraft:table_bonus",
-				  "enchantment": "minecraft:fortune",
-				  "chances": [
-					0.05,
-					0.0625,
-					0.083333336,
-					0.1
-				  ]
-				}
-			  ],
-			  "name": "traverse:red_autumnal_sapling"
-			}
-		  ]
-		}
-	  ]
-	},
-	{
-	  "rolls": 1,
-	  "entries": [
-		{
-		  "type": "minecraft:item",
-		  "conditions": [
-			{
-			  "condition": "minecraft:table_bonus",
-			  "enchantment": "minecraft:fortune",
-			  "chances": [
-				0.02,
-				0.022222223,
-				0.025,
-				0.033333335,
-				0.1
-			  ]
-			}
-		  ],
-		  "functions": [
-			{
-			  "function": "minecraft:set_count",
-			  "count": {
-				"min": 1.0,
-				"max": 2.0,
-				"type": "minecraft:uniform"
-			  }
-			},
-			{
-			  "function": "minecraft:explosion_decay"
-			}
-		  ],
-		  "name": "minecraft:stick"
-		}
-	  ],
-	  "conditions": [
-		{
-		  "condition": "minecraft:inverted",
-		  "term": {
-			"condition": "minecraft:alternative",
-			"terms": [
-			  {
-				"condition": "minecraft:match_tool",
-				"predicate": {
-				  "item": "minecraft:shears"
-				}
-			  },
-			  {
-				"condition": "minecraft:match_tool",
-				"predicate": {
-				  "enchantments": [
-					{
-					  "enchantment": "minecraft:silk_touch",
-					  "levels": {
-						"min": 1
-					  }
-					}
-				  ]
-				}
-			  }
-			]
-		  }
-		}
-	  ]
-	}
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:alternative",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "items": [
+                          "minecraft:shears"
+                        ]
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "enchantments": [
+                          {
+                            "enchantment": "minecraft:silk_touch",
+                            "levels": {
+                              "min": 1
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "traverse:red_autumnal_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:table_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "chances": [
+                    0.05,
+                    0.0625,
+                    0.083333336,
+                    0.1
+                  ]
+                }
+              ],
+              "name": "traverse:red_autumnal_sapling"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune",
+              "chances": [
+                0.02,
+                0.022222223,
+                0.025,
+                0.033333335,
+                0.1
+              ]
+            }
+          ],
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              },
+              "add": false
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:alternative",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "enchantments": [
+                    {
+                      "enchantment": "minecraft:silk_touch",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
   ]
 }

--- a/src/main/resources/data/traverse/loot_tables/blocks/yellow_autumnal_leaves.json
+++ b/src/main/resources/data/traverse/loot_tables/blocks/yellow_autumnal_leaves.json
@@ -1,128 +1,135 @@
 {
   "type": "minecraft:block",
   "pools": [
-	{
-	  "rolls": 1,
-	  "entries": [
-		{
-		  "type": "minecraft:alternatives",
-		  "children": [
-			{
-			  "type": "minecraft:item",
-			  "conditions": [
-				{
-				  "condition": "minecraft:alternative",
-				  "terms": [
-					{
-					  "condition": "minecraft:match_tool",
-					  "predicate": {
-						"item": "minecraft:shears"
-					  }
-					},
-					{
-					  "condition": "minecraft:match_tool",
-					  "predicate": {
-						"enchantments": [
-						  {
-							"enchantment": "minecraft:silk_touch",
-							"levels": {
-							  "min": 1
-							}
-						  }
-						]
-					  }
-					}
-				  ]
-				}
-			  ],
-			  "name": "traverse:yellow_autumnal_leaves"
-			},
-			{
-			  "type": "minecraft:item",
-			  "conditions": [
-				{
-				  "condition": "minecraft:survives_explosion"
-				},
-				{
-				  "condition": "minecraft:table_bonus",
-				  "enchantment": "minecraft:fortune",
-				  "chances": [
-					0.05,
-					0.0625,
-					0.083333336,
-					0.1
-				  ]
-				}
-			  ],
-			  "name": "traverse:yellow_autumnal_sapling"
-			}
-		  ]
-		}
-	  ]
-	},
-	{
-	  "rolls": 1,
-	  "entries": [
-		{
-		  "type": "minecraft:item",
-		  "conditions": [
-			{
-			  "condition": "minecraft:table_bonus",
-			  "enchantment": "minecraft:fortune",
-			  "chances": [
-				0.02,
-				0.022222223,
-				0.025,
-				0.033333335,
-				0.1
-			  ]
-			}
-		  ],
-		  "functions": [
-			{
-			  "function": "minecraft:set_count",
-			  "count": {
-				"min": 1.0,
-				"max": 2.0,
-				"type": "minecraft:uniform"
-			  }
-			},
-			{
-			  "function": "minecraft:explosion_decay"
-			}
-		  ],
-		  "name": "minecraft:stick"
-		}
-	  ],
-	  "conditions": [
-		{
-		  "condition": "minecraft:inverted",
-		  "term": {
-			"condition": "minecraft:alternative",
-			"terms": [
-			  {
-				"condition": "minecraft:match_tool",
-				"predicate": {
-				  "item": "minecraft:shears"
-				}
-			  },
-			  {
-				"condition": "minecraft:match_tool",
-				"predicate": {
-				  "enchantments": [
-					{
-					  "enchantment": "minecraft:silk_touch",
-					  "levels": {
-						"min": 1
-					  }
-					}
-				  ]
-				}
-			  }
-			]
-		  }
-		}
-	  ]
-	}
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:alternative",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "items": [
+                          "minecraft:shears"
+                        ]
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "enchantments": [
+                          {
+                            "enchantment": "minecraft:silk_touch",
+                            "levels": {
+                              "min": 1
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "traverse:yellow_autumnal_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:table_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "chances": [
+                    0.05,
+                    0.0625,
+                    0.083333336,
+                    0.1
+                  ]
+                }
+              ],
+              "name": "traverse:yellow_autumnal_sapling"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune",
+              "chances": [
+                0.02,
+                0.022222223,
+                0.025,
+                0.033333335,
+                0.1
+              ]
+            }
+          ],
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              },
+              "add": false
+            },
+            {
+              "function": "minecraft:explosion_decay"
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:alternative",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "enchantments": [
+                    {
+                      "enchantment": "minecraft:silk_touch",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Closes #70

Slight format change for the match_tool predicate from a string to a string array. I also added `"bonus_rolls": 0.0` and  `"add": false` since they're in vanilla leaf loot tables, but I don't think it makes a functional difference.