### PR TITLE
Fix panorama (port to Vistas 1.4)

### DIFF
--- a/src/main/resources/assets/traverse/panoramas.json
+++ b/src/main/resources/assets/traverse/panoramas.json
@@ -1,11 +1,13 @@
 {
-  "Autumnal Woods, Woodlands, and Rolling Hills": {
-    "name": "autumnal_woods_woodlands_and_rolling_hills",
-    "panoramaId": "traverse:textures/gui/panorama/panorama",
-    "musicId": "minecraft:music.menu",
-    "movementSettings": {
-      "addedY": 0.0
-    }
+  "autumnal_woods_woodlands_and_rolling_hills": {
+    "music": "minecraft:music.menu",
+    "panoramas": [
+      {
+        "backgroundId": "traverse:textures/gui/panorama/panorama",
+        "movementSettings": {
+          "addedY": 0.0
+        }
+      }
+    ]
   }
-}
 }


### PR DESCRIPTION
Vistas 1.4 for 1.17.1 changed their API ([old one](https://github.com/TerraformersMC/Vistas/wiki/Documentation/75ba716748b76ccb0d2c5d0668e048105cd28e5d), [new one](https://github.com/TerraformersMC/Vistas/wiki/Documentation)).

It looks like the panorama was broken even before that since it had an extra `}` at the end?
Either way, this one seems to work fine.