### PR TITLE
Removed traverse:wooded_island from a couple of tags files.

### DIFF
--- a/src/main/java/com/terraformersmc/traverse/biome/AutumnalWoodsBiomes.java
+++ b/src/main/java/com/terraformersmc/traverse/biome/AutumnalWoodsBiomes.java
@@ -1,17 +1,13 @@
 package com.terraformersmc.traverse.biome;
 
-import com.terraformersmc.traverse.feature.TraverseConfiguredFeatures;
 import com.terraformersmc.traverse.feature.TraversePlacedFeatures;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnGroup;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.GenerationSettings;
-import net.minecraft.world.biome.OverworldBiomeCreator;
 import net.minecraft.world.biome.SpawnSettings;
 import net.minecraft.world.gen.GenerationStep;
-import net.minecraft.world.gen.feature.ConfiguredStructureFeatures;
 import net.minecraft.world.gen.feature.DefaultBiomeFeatures;
-import net.minecraft.world.gen.feature.VegetationPlacedFeatures;
 
 import static com.terraformersmc.traverse.biome.TraverseBiomes.addBasicFeatures;
 
@@ -40,10 +36,10 @@ public class AutumnalWoodsBiomes {
 	private static GenerationSettings generationSettings(){
 		GenerationSettings.Builder builder = new GenerationSettings.Builder();
 		addBasicFeatures(builder);
-		DefaultBiomeFeatures.addForestFlowers(builder);
 		DefaultBiomeFeatures.addDefaultOres(builder);
 		DefaultBiomeFeatures.addDefaultDisks(builder);
 		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, TraversePlacedFeatures.AUTUMNAL_TREES);
+		DefaultBiomeFeatures.addForestFlowers(builder);
 		DefaultBiomeFeatures.addDefaultFlowers(builder);
 		DefaultBiomeFeatures.addForestGrass(builder);
 		DefaultBiomeFeatures.addDefaultMushrooms(builder);

--- a/src/main/java/com/terraformersmc/traverse/biome/DesertShrublandBiomes.java
+++ b/src/main/java/com/terraformersmc/traverse/biome/DesertShrublandBiomes.java
@@ -5,7 +5,6 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnGroup;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.GenerationSettings;
-import net.minecraft.world.biome.OverworldBiomeCreator;
 import net.minecraft.world.biome.SpawnSettings;
 import net.minecraft.world.gen.GenerationStep;
 import net.minecraft.world.gen.feature.DefaultBiomeFeatures;
@@ -31,13 +30,13 @@ public class DesertShrublandBiomes {
 		addBasicFeatures(builder);
 		DefaultBiomeFeatures.addDefaultOres(builder);
 		DefaultBiomeFeatures.addDefaultDisks(builder);
+		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, TraversePlacedFeatures.DESERT_SHRUBS);
 		DefaultBiomeFeatures.addDefaultFlowers(builder);
 		DefaultBiomeFeatures.addDefaultGrass(builder);
 		DefaultBiomeFeatures.addDesertDeadBushes(builder);
 		DefaultBiomeFeatures.addDefaultMushrooms(builder);
 		DefaultBiomeFeatures.addDesertVegetation(builder);
 		DefaultBiomeFeatures.addDesertFeatures(builder);
-		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, TraversePlacedFeatures.DESERT_SHRUBS);
 		return builder.build();
 	}
 

--- a/src/main/java/com/terraformersmc/traverse/biome/FlatlandsBiomes.java
+++ b/src/main/java/com/terraformersmc/traverse/biome/FlatlandsBiomes.java
@@ -4,6 +4,9 @@ import com.terraformersmc.traverse.feature.TraversePlacedFeatures;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.GenerationSettings;
 import net.minecraft.world.gen.GenerationStep;
+import net.minecraft.world.gen.feature.DefaultBiomeFeatures;
+
+import static com.terraformersmc.traverse.biome.TraverseBiomes.addBasicFeatures;
 
 public class FlatlandsBiomes {
 	static final Biome FLATLANDS = TraverseBiomes.BIOME_TEMPLATE
@@ -22,11 +25,15 @@ public class FlatlandsBiomes {
 			.build();
 
 	private static GenerationSettings generationSettings(){
-		GenerationSettings.Builder builder = TraverseBiomes.createDefaultGenerationSettings();
-		//DefaultBiomeFeatures.addDefaultLakes(builder);
-		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, TraversePlacedFeatures.MEADOW_GRASS);
-		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, TraversePlacedFeatures.LUSH_FLOWERS);
+		GenerationSettings.Builder builder = new GenerationSettings.Builder();
+		addBasicFeatures(builder);
+		DefaultBiomeFeatures.addDefaultOres(builder);
+		DefaultBiomeFeatures.addDefaultDisks(builder);
 		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, TraversePlacedFeatures.MEADOW_TREES);
+		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, TraversePlacedFeatures.LUSH_FLOWERS);
+		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, TraversePlacedFeatures.MEADOW_GRASS);
+		DefaultBiomeFeatures.addDefaultMushrooms(builder);
+		DefaultBiomeFeatures.addDefaultVegetation(builder);
 		return builder.build();
 	}
 }

--- a/src/main/java/com/terraformersmc/traverse/biome/LushSwampBiomes.java
+++ b/src/main/java/com/terraformersmc/traverse/biome/LushSwampBiomes.java
@@ -1,6 +1,5 @@
 package com.terraformersmc.traverse.biome;
 
-import com.terraformersmc.traverse.feature.TraverseConfiguredFeatures;
 import com.terraformersmc.traverse.feature.TraversePlacedFeatures;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnGroup;
@@ -10,7 +9,8 @@ import net.minecraft.world.biome.SpawnSettings;
 import net.minecraft.world.gen.GenerationStep;
 import net.minecraft.world.gen.feature.DefaultBiomeFeatures;
 import net.minecraft.world.gen.feature.OceanPlacedFeatures;
-import net.minecraft.world.gen.feature.VegetationPlacedFeatures;
+
+import static com.terraformersmc.traverse.biome.TraverseBiomes.addBasicFeatures;
 
 public class LushSwampBiomes {
 
@@ -32,24 +32,15 @@ public class LushSwampBiomes {
 
 	public static GenerationSettings generationSettings(){
 		GenerationSettings.Builder builder = new GenerationSettings.Builder();
-		DefaultBiomeFeatures.addLandCarvers(builder);
-		DefaultBiomeFeatures.addDungeons(builder);
-		DefaultBiomeFeatures.addMineables(builder);
-		DefaultBiomeFeatures.addDefaultOres(builder);
-		DefaultBiomeFeatures.addDefaultMushrooms(builder);
-		DefaultBiomeFeatures.addDefaultVegetation(builder);
-		DefaultBiomeFeatures.addSprings(builder);
-		DefaultBiomeFeatures.addFrozenTopLayer(builder);
-		//DefaultBiomeFeatures.addLakes();
-		DefaultBiomeFeatures.addSwampVegetation(builder);
 		DefaultBiomeFeatures.addFossils(builder);
-		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, OceanPlacedFeatures.SEAGRASS_SWAMP);
+		addBasicFeatures(builder);
+		DefaultBiomeFeatures.addDefaultOres(builder);
+		DefaultBiomeFeatures.addClayDisk(builder);
 		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, TraversePlacedFeatures.LUSH_SWAMP_TREES);
-		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, VegetationPlacedFeatures.FLOWER_SWAMP);
-		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, VegetationPlacedFeatures.PATCH_GRASS_NORMAL);
-		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, VegetationPlacedFeatures.PATCH_WATERLILY);
-		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, VegetationPlacedFeatures.BROWN_MUSHROOM_SWAMP);
-		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, VegetationPlacedFeatures.RED_MUSHROOM_SWAMP);
+		DefaultBiomeFeatures.addSwampFeatures(builder);
+		DefaultBiomeFeatures.addDefaultMushrooms(builder);
+		DefaultBiomeFeatures.addSwampVegetation(builder);
+		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, OceanPlacedFeatures.SEAGRASS_SWAMP);
 		return builder.build();
 	}
 

--- a/src/main/java/com/terraformersmc/traverse/biome/WoodedIslandBiomes.java
+++ b/src/main/java/com/terraformersmc/traverse/biome/WoodedIslandBiomes.java
@@ -8,6 +8,8 @@ import net.minecraft.world.biome.GenerationSettings;
 import net.minecraft.world.biome.SpawnSettings;
 import net.minecraft.world.gen.feature.DefaultBiomeFeatures;
 
+import static com.terraformersmc.traverse.biome.TraverseBiomes.addBasicFeatures;
+
 public class WoodedIslandBiomes {
 	static final Biome WOODED_ISLAND = TraverseBiomes.BIOME_TEMPLATE
 			//.configureSurfaceBuilder(TraverseSurfaceRules.WOODED_ISLAND, SurfaceBuilder.GRASS_CONFIG)
@@ -21,12 +23,16 @@ public class WoodedIslandBiomes {
 			.downfall(0.8F)
 			.build();
 	private static GenerationSettings generationSettings(){
-		GenerationSettings.Builder builder = TraverseBiomes.createDefaultGenerationSettings();
-		//DefaultBiomeFeatures.addDefaultLakes(builder);
+		GenerationSettings.Builder builder = new GenerationSettings.Builder();
+		addBasicFeatures(builder);
 		DefaultBiomeFeatures.addForestFlowers(builder);
+		DefaultBiomeFeatures.addDefaultOres(builder);
+		DefaultBiomeFeatures.addDefaultDisks(builder);
+		DefaultBiomeFeatures.addForestTrees(builder);
 		DefaultBiomeFeatures.addDefaultFlowers(builder);
 		DefaultBiomeFeatures.addForestGrass(builder);
-		DefaultBiomeFeatures.addForestTrees(builder);
+		DefaultBiomeFeatures.addDefaultMushrooms(builder);
+		DefaultBiomeFeatures.addDefaultVegetation(builder);
 		DefaultBiomeFeatures.addLessKelp(builder);
 		return builder.build();
 	}

--- a/src/main/java/com/terraformersmc/traverse/biome/WoodlandsBiomes.java
+++ b/src/main/java/com/terraformersmc/traverse/biome/WoodlandsBiomes.java
@@ -1,6 +1,5 @@
 package com.terraformersmc.traverse.biome;
 
-import com.terraformersmc.traverse.feature.TraverseConfiguredFeatures;
 import com.terraformersmc.traverse.feature.TraversePlacedFeatures;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnGroup;
@@ -8,7 +7,6 @@ import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.GenerationSettings;
 import net.minecraft.world.biome.SpawnSettings;
 import net.minecraft.world.gen.GenerationStep;
-import net.minecraft.world.gen.feature.ConfiguredStructureFeatures;
 import net.minecraft.world.gen.feature.DefaultBiomeFeatures;
 
 import static com.terraformersmc.traverse.biome.TraverseBiomes.addBasicFeatures;
@@ -32,10 +30,10 @@ public class WoodlandsBiomes {
 	private static GenerationSettings generationSettings(){
 		GenerationSettings.Builder builder = new GenerationSettings.Builder();
 		addBasicFeatures(builder);
-		DefaultBiomeFeatures.addForestFlowers(builder);
 		DefaultBiomeFeatures.addDefaultOres(builder);
 		DefaultBiomeFeatures.addDefaultDisks(builder);
 		builder.feature(GenerationStep.Feature.VEGETAL_DECORATION, TraversePlacedFeatures.WOODLANDS_TREES);
+		DefaultBiomeFeatures.addForestFlowers(builder);
 		DefaultBiomeFeatures.addDefaultFlowers(builder);
 		DefaultBiomeFeatures.addForestGrass(builder);
 		DefaultBiomeFeatures.addDefaultMushrooms(builder);

--- a/src/main/java/com/terraformersmc/traverse/feature/TraversePlacedFeatures.java
+++ b/src/main/java/com/terraformersmc/traverse/feature/TraversePlacedFeatures.java
@@ -62,7 +62,7 @@ public class TraversePlacedFeatures {
 
 	/* Swamp Trees */
 	public static final RegistryEntry<PlacedFeature> TALL_SWAMP_TREE = createPlacedFeature("tall_swamp_tree", TraverseConfiguredFeatures.TALL_SWAMP_TREE, SurfaceWaterDepthFilterPlacementModifier.of(1));
-	public static final RegistryEntry<PlacedFeature> LUSH_SWAMP_TREES = createPlacedFeature("lush_swamp_trees", TraverseConfiguredFeatures.TALL_SWAMP_TREE, PlacedFeatures.createCountExtraModifier(2, 0.1f, 1), SquarePlacementModifier.of(), PlacedFeatures.MOTION_BLOCKING_HEIGHTMAP, SurfaceWaterDepthFilterPlacementModifier.of(1), BlockFilterPlacementModifier.of(BlockPredicate.matchingBlockTag(BlockTags.DIRT, Direction.DOWN.getVector())));
+	public static final RegistryEntry<PlacedFeature> LUSH_SWAMP_TREES = createPlacedFeature("lush_swamp_trees", TraverseConfiguredFeatures.TALL_SWAMP_TREE, PlacedFeatures.createCountExtraModifier(2, 0.1f, 1), SquarePlacementModifier.of(), PlacedFeatures.OCEAN_FLOOR_HEIGHTMAP, SurfaceWaterDepthFilterPlacementModifier.of(2), BlockFilterPlacementModifier.of(BlockPredicate.matchingBlockTag(BlockTags.DIRT, Direction.DOWN.getVector())));
 
 	/* Lush Vegetation */
 	public static final RegistryEntry<PlacedFeature> LUSH_FLOWERS = createPlacedFeature("lush_flowers", TraverseConfiguredFeatures.LUSH_FLOWERS, RarityFilterPlacementModifier.of(32), CountPlacementModifier.of(10), SquarePlacementModifier.of(), PlacedFeatures.MOTION_BLOCKING_HEIGHTMAP, BlockFilterPlacementModifier.of(BlockPredicate.matchingBlockTag(BlockTags.DIRT, Direction.DOWN.getVector())));

--- a/src/main/java/com/terraformersmc/traverse/surfacerules/TraverseSurfaceRules.java
+++ b/src/main/java/com/terraformersmc/traverse/surfacerules/TraverseSurfaceRules.java
@@ -1,6 +1,5 @@
 package com.terraformersmc.traverse.surfacerules;
 
-import com.google.common.collect.ImmutableList;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.terraformersmc.traverse.Traverse;
@@ -11,15 +10,13 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.noise.DoublePerlinNoiseSampler;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
-import net.minecraft.world.biome.BiomeKeys;
 import net.minecraft.world.gen.YOffset;
 import net.minecraft.world.gen.noise.NoiseParametersKeys;
 import net.minecraft.world.gen.surfacebuilder.MaterialRules;
 import net.minecraft.world.gen.surfacebuilder.MaterialRules.MaterialRule;
 import net.minecraft.world.gen.surfacebuilder.VanillaSurfaceRules;
 
-import static net.minecraft.world.gen.surfacebuilder.MaterialRules.condition;
-import static net.minecraft.world.gen.surfacebuilder.MaterialRules.sequence;
+import static net.minecraft.world.gen.surfacebuilder.MaterialRules.*;
 
 public class TraverseSurfaceRules {
 
@@ -36,9 +33,7 @@ public class TraverseSurfaceRules {
 	}
 
 	public static MaterialRule createRules(){
-		MaterialRule defaultGrass = condition(MaterialRules.STONE_DEPTH_FLOOR, sequence(
-				condition(MaterialRules.water(-1, 0), block(Blocks.GRASS_BLOCK)),
-				block(Blocks.DIRT)));
+		MaterialRule defaultGrass = VanillaSurfaceRules.createDefaultRule(true, false, true);
 		MaterialRule sandAndSandstone = sequence(condition(MaterialRules.STONE_DEPTH_CEILING, block(Blocks.SANDSTONE)), block(Blocks.SAND));
 		MaterialRule desertShrubland = condition(MaterialRules.biome(TraverseBiomes.DESERT_SHRUBLAND), new SandWithPatchesSurfaceRule(1.5D, NoiseParametersKeys.SURFACE, defaultGrass, sandAndSandstone));
 		MaterialRule aridHighlands = condition(MaterialRules.biome(TraverseBiomes.ARID_HIGHLANDS), new SandWithPatchesSurfaceRule(0.9D, NoiseParametersKeys.SURFACE, defaultGrass, sandAndSandstone));
@@ -47,6 +42,9 @@ public class TraverseSurfaceRules {
 						condition(MaterialRules.aboveY(YOffset.fixed(62), 0),
 								condition(MaterialRules.not(MaterialRules.aboveY(YOffset.fixed(63), 0)),
 										condition(MaterialRules.noiseThreshold(NoiseParametersKeys.SURFACE_SWAMP, 0.0), block(Blocks.WATER))))));
+		// I have no idea how to do this...  Still trying to understand if it's even possible to make islands in 1.18.
+		//MaterialRule woodedIsland = condition(MaterialRules.biome(TraverseBiomes.WOODED_ISLAND),
+		//				condition(stoneDepth(62, true, VerticalSurfaceType.CEILING), block(Blocks.STONE)));
 
 		return sequence(condition(MaterialRules.surface(), sequence(desertShrubland, aridHighlands, lushSwamp)), defaultGrass);
 	}

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/has_structure/stronghold.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/has_structure/stronghold.json
@@ -3,7 +3,6 @@
   "values": [
     "traverse:lush_swamp",
     "traverse:rolling_hills",
-    "traverse:wooded_island",
     "traverse:mini_jungle",
     "traverse:woodlands",
     "traverse:arid_highlands",

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/is_forest.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/is_forest.json
@@ -1,7 +1,6 @@
 {
   "replace": false,
   "values": [
-    "traverse:wooded_island",
     "traverse:woodlands",
     "traverse:autumnal_woods",
     "traverse:coniferous_forest",


### PR DESCRIPTION
Quick fix for #84.  I checked the other tags files and it looks like wooded_island is the only problem.

However, it's worth noting `is_mountain.json` and `is_taiga.json` both contain nothing but vanilla biomes and I think that means they could be removed.